### PR TITLE
chore: Point ESLint at all `tsconfig.json`s

### DIFF
--- a/eslint.packages.js
+++ b/eslint.packages.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: ['./node_modules/hd-scripts/eslint/ts.js'],
   parserOptions: {
-    project: './tsconfig.json',
+    project: ['./tsconfig.json', 'packages/*/tsconfig.json'],
     ecmaFeatures: {
       jsx: true,
     },


### PR DESCRIPTION
Otherwise it can't lint everything. This is solved with the [`projectService` option][1] in [`@typescript-eslint/parser` v8][2]. However, we're stuck firmly on v5 for now.

[1]: https://github.com/typescript-eslint/typescript-eslint/pull/8031/files?short_path=f55b3fe#diff-f55b3fe275ea73e5e0cbfaf72c238d8fa863819992fe17e23668d1f0376a18b4
[2]: https://github.com/typescript-eslint/typescript-eslint/commit/b9796c1ac49d36a9d372794371c558589c19f5a3

### Before

```sh
$ pnpm exec eslint packages/react/src/Uploader.tsx

/Users/peeja/clients/storacha/w3ui/packages/react/src/Uploader.tsx
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/packages/react/src/Uploader.tsx` using `parserOptions.project`: /users/peeja/clients/storacha/w3ui/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file

✖ 1 problem (1 error, 0 warnings)
```

### After
```sh
pnpm exec eslint packages/react/src/Uploader.tsx

/Users/peeja/clients/storacha/w3ui/packages/react/src/Uploader.tsx
  188:23  warning  Do not nest ternary expressions                                                                                                                                                      no-nested-ternary
  190:16  warning  Do not nest ternary expressions                                                                                                                                                      no-nested-ternary
  230:9   warning  React Hook useMemo has missing dependencies: 'files', 'storedDAGShards', 'uploadAsCAR', 'uploadProgress', and 'wrapInDirectory'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
  294:5   warning  React Hook useCallback has a missing dependency: 'setWrapInDirectory'. Either include it or remove the dependency array                                                              react-hooks/exhaustive-deps

✖ 4 problems (0 errors, 4 warnings)
```

(Which, y'know, still not ideal, but at least it's _running_.)